### PR TITLE
Fix mapping of poolaccounts and home folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ poolaccounts_enable_groupmapfile: false
 poolaccounts_enable_cleanup: false
 poolaccounts_cleanup_uid_min: 1000
 poolaccounts_cleanup_verbose: false
+poolaccounts_create_accounts: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     name: "{{ item.group }}"
     gid: "{{ item.gid }}"
   loop: "{{ poolaccounts }}"
+  when: "poolaccounts_create_accounts | bool"
   loop_control:
     label: "{{ item.group }}"
 
@@ -26,8 +27,8 @@
 
 - name: Configure grid-mapfile
   template:
-    src: grid-mapfile.j2
-    dest: /etc/grid-security/grid-mapfile
+    src: voms-mapfile.j2
+    dest: /etc/grid-security/voms-mapfile
   when: poolaccounts_enable_grid_mapfile
 
 - name: Configure groupmapfile

--- a/tasks/poolaccount.yml
+++ b/tasks/poolaccount.yml
@@ -6,12 +6,12 @@
     uid: "{{ account.uid + idx * (account.step | default(1)) }}"
     group: "{{ account.group }}"
     groups: "{{ account.groups | default([]) }}"
-    home: "{{ poolaccounts_homedir + '/' + (account.name | format(idx) ) }}"
+    home: "{{ poolaccounts_homedir + '/' + (account.name | format(idx+1) ) }}"
   loop: "{{ range(account.number) | list }}"
   loop_control:
     label: "{{ account.name | format(idx+1) }}"
     index_var: idx
-  when: account.number is defined
+  when: account.number is defined and poolaccounts_create_accounts | bool
 
 - name: Create entry in gridmapdir
   file:
@@ -34,7 +34,7 @@
     group: "{{ account.group }}"
     groups: "{{ account.groups | default([]) }}"
     home: "{{ poolaccounts_homedir + '/' + account.name }}"
-  when: account.number is not defined
+  when: account.number is not defined and poolaccounts_create_accounts | bool
 
 - name: Create entry in gridmapdir
   file:

--- a/templates/voms-mapfile.j2
+++ b/templates/voms-mapfile.j2
@@ -1,8 +1,8 @@
 {{ ansible_managed | comment }}
 {% for account in poolaccounts %}
 {%   if account.number is defined %}
-"{{ account.fqan }}/Capability=NULL" .{{ account.group }}
-"{{ account.fqan }}" .{{ account.group }}
+"{{ account.fqan }}/Capability=NULL" .{{ account.name[:-4] }}
+"{{ account.fqan }}" .{{ account.name[:-4] }}
 {%   else %}
 "{{ account.fqan }}/Capability=NULL" {{ account.name }}
 "{{ account.fqan }}" {{ account.name }}


### PR DESCRIPTION
Bugfix of home folder to match the user cms001 -> /home/cms001
Rename grid-mapfile to voms-mapfile because we target VO information
and not DN as it is done in the grid-mapfile